### PR TITLE
Inject a mechanism that allows you to serve uploads via proxy.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,13 @@
 pipeline:
+  tests:
+    image: jpetazzo/dind
+    commands:
+      - docker build --rm --build-arg PHP_VERSION=7.2 -t presslabs/php-runtime .
+      - docker run --rm -e UPLOADS=/test -e UPLOADS_HTTP_PROXY=google.com presslabs/php-runtime /usr/bin/openresty -t -c /usr/local/docker/etc/nginx.conf
+      - docker rmi presslabs/php-runtime
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
   publish-slim-docker-image:
     image: plugins/docker
     registry: quay.io

--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ PHP docker images with batteries included for running WordPress
 * `SMTP_TLS` (default to `yes`)
 * `WORKER_GROUP` (default to `www-data`)
 * `WORKER_USER` (default to `www-data`)
+* `UPLOADS_HTTP_PROXY` (default to `127.0.0.1`) - used to serve Wordpress uploads
+from another upstream.
+* `UPLOADS` (default to `/wp-content/uploads`) - path to media uploads. It needs
+to be the same as in your Wordpress configuration in order to proxy the requests 
+to `UPLOADS_HTTP_PROXY`.

--- a/docker/templates/nginx-vhost-conf.d/70-uploads.conf
+++ b/docker/templates/nginx-vhost-conf.d/70-uploads.conf
@@ -1,0 +1,9 @@
+location ^~ {{ default "/wp-content/uploads" .Env.UPLOADS}}/ {
+    location ~ /$ {
+        return 403;
+    }
+
+    location {{ default "/wp-content/uploads" .Env.UPLOADS}}/ {
+        proxy_pass http://{{ default "127.0.0.1" .Env.UPLOADS_HTTP_PROXY}};
+    }
+}


### PR DESCRIPTION
Adds two new constants: `UPLOADS` that is the URL prefix for each uploaded file (default to `/wp-content/uploads`) and `UPLOADS_HTTP_PROXY` that represents a host from which the uploads are served (default to `127.0.0.1`).

Reference https://github.com/presslabs/wordpress-integration/issues/11

#### Tests
- `git checkout uploads-http-proxy`
- `docker build -t presslabs/php-runtime .`
- `docker network create rclone`
- `docker run -p 8080:8080 --network=rclone --name=rclone quay.io/presslabs/rclone serve http . --addr 0.0.0.0:8080`
- `docker run -p 8081:80 --network=rclone -e UPLOADS=/etc -e UPLOADS_HTTP_PROXY=rclone:8080 presslabs/php-runtime`
- `curl http://localhost:8080/etc/rclone.conf` should be the same with `curl http://localhost:8081/etc/rclone.conf`
- `curl -SI http://localhost:8081/etc/` should throw `403`
- `curl -SI http://localhost:8081/etc` should display php info