### PR TITLE
Add COMPOSER_AUTH env var as onbuild arg

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -59,6 +59,7 @@ push-$(RUNTIME)-%: .build/tag-$(RUNTIME)-%
 	$(DOCKER_BUILD) \
 		$(patsubst %,--build-arg BASE_IMAGE=%,$(BASE_IMAGE)) \
 		$(patsubst %,--build-arg PHP_BASE_IMAGE=%,$(PHP_BASE_IMAGE)) \
+		--build-arg COMPOSER_AUTH= \
 		-t local$@ \
 		--cache-from $(REGISTRY):$(@:.build/$(RUNTIME)-%=%) \
 		--cache-from $(REGISTRY):$(@:.build/$(RUNTIME)-%=%)$(TAG_SUFFIX_SLUG) \

--- a/wordpress/Dockerfile-bedrock-build
+++ b/wordpress/Dockerfile-bedrock-build
@@ -1,11 +1,17 @@
 ARG BASE_IMAGE=quay.io/presslabs/wordpress-runtime:bedrock
 FROM ${BASE_IMAGE} as bedrock
 WORKDIR /src
+
+# Inject custom env vars as build args
+ONBUILD ARG COMPOSER_AUTH
+ONBUILD ENV COMPOSER_AUTH ${COMPOSER_AUTH}
+
 # Install project dependencies as first build step for child images so that we
 # heat up composer cache
+# ONBUILD COPY --chown=www-data:www-data composer.json composer.lock auth.json /src/
 ONBUILD COPY --chown=www-data:www-data composer.json composer.lock /src/
-ONBUILD RUN composer install --no-dev --no-interaction --no-progress --no-ansi --no-scripts
+ONBUILD RUN COMPOSER_AUTH=${COMPOSER_AUTH} composer install --no-dev --no-interaction --no-progress --no-ansi --no-scripts
 
 ONBUILD COPY --chown=www-data:www-data . /src
-ONBUILD RUN composer install --no-dev --no-interaction --no-progress --no-ansi --no-scripts
+ONBUILD RUN COMPOSER_AUTH=${COMPOSER_AUTH} composer install --no-dev --no-interaction --no-progress --no-ansi --no-scripts
 ONBUILD RUN cp -a /src/. /app

--- a/wordpress/Dockerfile-bedrock-build
+++ b/wordpress/Dockerfile-bedrock-build
@@ -8,7 +8,6 @@ ONBUILD ENV COMPOSER_AUTH ${COMPOSER_AUTH}
 
 # Install project dependencies as first build step for child images so that we
 # heat up composer cache
-# ONBUILD COPY --chown=www-data:www-data composer.json composer.lock auth.json /src/
 ONBUILD COPY --chown=www-data:www-data composer.json composer.lock /src/
 ONBUILD RUN COMPOSER_AUTH=${COMPOSER_AUTH} composer install --no-dev --no-interaction --no-progress --no-ansi --no-scripts
 


### PR DESCRIPTION
Adds the ability to inject a custom [`COMPOSER_AUTH`](https://getcomposer.org/doc/03-cli.md#composer-auth) build arg as environment variable, which can be set by downstream Docker images to enable basic-auth for composer configurations requiring authentication.