### PR TITLE
Manually install imagick extension for PHP 8 stack

### DIFF
--- a/php/Dockerfile-8.0
+++ b/php/Dockerfile-8.0
@@ -32,12 +32,18 @@ RUN set -ex \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         msmtp unzip openresty=1.13* openresty-debug=1.13* libyaml-0-2 libyaml-dev \
-        less git openssh-client procps \
+        less git openssh-client procps libmagickwand-dev \
     # we need yaml support for installing extensions
     && pecl install yaml \
     && docker-php-ext-enable --ini-name 50-docker-php-ext-yaml.ini yaml \
     && apt-get autoremove --purge -y libyaml-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# manually download and install working Imagick extension build
+RUN set -ex \
+    && mkdir -p /usr/src/php/ext/imagick \
+    && curl -fsSL https://github.com/Imagick/imagick/archive/06116aa24b76edaf6b1693198f79e6c295eda8a9.tar.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1 \
+    && docker-php-ext-install imagick
 
 COPY docker/build-scripts /usr/local/docker/build-scripts/
 


### PR DESCRIPTION
Imagick is still in the php-extensions.yaml but will be fixed because it's already installed earlier in the Dockerfile.