### PR TITLE
Build images for WordPress 6.7

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -586,6 +586,222 @@ services:
       DOCKER_TLS_CERTDIR: ""
 ---
 kind: pipeline
+name: wordpress-runtime-6.7-php-7.4
+
+depends_on:
+  - wordpress-runtime-bedrock-php-7.4
+
+workspace:
+  base: /workspace
+  path: src/github.com/bitpoke/stack-runtimes
+
+steps:
+  - &step
+    name: setup docker
+    pull: always
+    image: docker.io/bitpoke/build:v0.8.0
+    environment: &baseEnv
+      TAG_SUFFIX: ${DRONE_BRANCH/master/}
+      TEST_HOSTNAME: docker
+      DOCKER_HOST: tcp://docker:2375
+    commands:
+      - dockerize -wait http://docker:2375/_ping -timeout 30s
+      - docker info
+      - make -C wordpress pull-$DRONE_STAGE_NAME
+
+  - <<: *step
+    name: build image
+    pull: default
+    commands:
+      - make -C wordpress $DRONE_STAGE_NAME
+
+  - <<: *step
+    name: test image
+    pull: default
+    commands:
+      - make -C wordpress test-$DRONE_STAGE_NAME
+
+  - <<: *step
+    name: publish
+    pull: default
+    environment:
+      <<: *baseEnv
+      DOCKER_USERNAME: bitpokebot
+      DOCKER_PASSWORD:
+        from_secret: DOCKER_PASSWORD
+    commands:
+      - /usr/local/bin/setup-credentials-helper.sh
+      - make -C wordpress push-$DRONE_STAGE_NAME
+
+services:
+  - name: docker
+    image: docker:20.10.24-dind-rootless
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+---
+kind: pipeline
+name: wordpress-runtime-6.7
+
+depends_on:
+  - wordpress-runtime-bedrock
+
+workspace:
+  base: /workspace
+  path: src/github.com/bitpoke/stack-runtimes
+
+steps:
+  - &step
+    name: setup docker
+    pull: always
+    image: docker.io/bitpoke/build:v0.8.0
+    environment: &baseEnv
+      TAG_SUFFIX: ${DRONE_BRANCH/master/}
+      TEST_HOSTNAME: docker
+      DOCKER_HOST: tcp://docker:2375
+    commands:
+      - dockerize -wait http://docker:2375/_ping -timeout 30s
+      - docker info
+      - make -C wordpress pull-$DRONE_STAGE_NAME
+
+  - <<: *step
+    name: build image
+    pull: default
+    commands:
+      - make -C wordpress $DRONE_STAGE_NAME
+
+  - <<: *step
+    name: test image
+    pull: default
+    commands:
+      - make -C wordpress test-$DRONE_STAGE_NAME
+
+  - <<: *step
+    name: publish
+    pull: default
+    environment:
+      <<: *baseEnv
+      DOCKER_USERNAME: bitpokebot
+      DOCKER_PASSWORD:
+        from_secret: DOCKER_PASSWORD
+    commands:
+      - /usr/local/bin/setup-credentials-helper.sh
+      - make -C wordpress push-$DRONE_STAGE_NAME
+
+services:
+  - name: docker
+    image: docker:20.10.24-dind-rootless
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+---
+kind: pipeline
+name: wordpress-runtime-6.7-php-8.3
+
+depends_on:
+  - wordpress-runtime-bedrock-php-8.3
+
+workspace:
+  base: /workspace
+  path: src/github.com/bitpoke/stack-runtimes
+
+steps:
+  - &step
+    name: setup docker
+    pull: always
+    image: docker.io/bitpoke/build:v0.8.0
+    environment: &baseEnv
+      TAG_SUFFIX: ${DRONE_BRANCH/master/}
+      TEST_HOSTNAME: docker
+      DOCKER_HOST: tcp://docker:2375
+    commands:
+      - dockerize -wait http://docker:2375/_ping -timeout 30s
+      - docker info
+      - make -C wordpress pull-$DRONE_STAGE_NAME
+
+  - <<: *step
+    name: build image
+    pull: default
+    commands:
+      - make -C wordpress $DRONE_STAGE_NAME
+
+  - <<: *step
+    name: test image
+    pull: default
+    commands:
+      - make -C wordpress test-$DRONE_STAGE_NAME
+
+  - <<: *step
+    name: publish
+    pull: default
+    environment:
+      <<: *baseEnv
+      DOCKER_USERNAME: bitpokebot
+      DOCKER_PASSWORD:
+        from_secret: DOCKER_PASSWORD
+    commands:
+      - /usr/local/bin/setup-credentials-helper.sh
+      - make -C wordpress push-$DRONE_STAGE_NAME
+
+services:
+  - name: docker
+    image: docker:20.10.24-dind-rootless
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+---
+kind: pipeline
+name: wordpress-runtime-6.7-php-8.1
+
+depends_on:
+  - wordpress-runtime-bedrock-php-8.1
+
+workspace:
+  base: /workspace
+  path: src/github.com/bitpoke/stack-runtimes
+
+steps:
+  - &step
+    name: setup docker
+    pull: always
+    image: docker.io/bitpoke/build:v0.8.0
+    environment: &baseEnv
+      TAG_SUFFIX: ${DRONE_BRANCH/master/}
+      TEST_HOSTNAME: docker
+      DOCKER_HOST: tcp://docker:2375
+    commands:
+      - dockerize -wait http://docker:2375/_ping -timeout 30s
+      - docker info
+      - make -C wordpress pull-$DRONE_STAGE_NAME
+
+  - <<: *step
+    name: build image
+    pull: default
+    commands:
+      - make -C wordpress $DRONE_STAGE_NAME
+
+  - <<: *step
+    name: test image
+    pull: default
+    commands:
+      - make -C wordpress test-$DRONE_STAGE_NAME
+
+  - <<: *step
+    name: publish
+    pull: default
+    environment:
+      <<: *baseEnv
+      DOCKER_USERNAME: bitpokebot
+      DOCKER_PASSWORD:
+        from_secret: DOCKER_PASSWORD
+    commands:
+      - /usr/local/bin/setup-credentials-helper.sh
+      - make -C wordpress push-$DRONE_STAGE_NAME
+
+services:
+  - name: docker
+    image: docker:20.10.24-dind-rootless
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+---
+kind: pipeline
 name: wordpress-runtime-6.6-php-7.4
 
 depends_on:

--- a/wordpress/Dockerfile-6.7
+++ b/wordpress/Dockerfile-6.7
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE=docker.io/bitpoke/wordpress-runtime:bedrock-php-8.2
+FROM ${BASE_IMAGE} as bedrock
+ENV WORDPRESS_VERSION=6.7
+ENV WP_CONTENT_DIR=${DOCUMENT_ROOT}/wp-content
+ENV STACK_MEDIA_PATH=/wp-content/uploads
+RUN set -ex \
+    && wp core download --skip-content --path=web/wp --version=${WORDPRESS_VERSION} \
+    && cp /usr/local/docker/webroot/* /app/web/
+ONBUILD COPY --chown=www-data:www-data config /app/config
+ONBUILD COPY --chown=www-data:www-data wp-content /app/web/wp-content

--- a/wordpress/Dockerfile-6.7-php-7.4
+++ b/wordpress/Dockerfile-6.7-php-7.4
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE=docker.io/bitpoke/wordpress-runtime:bedrock-php-7.4
+FROM ${BASE_IMAGE} as bedrock
+ENV WORDPRESS_VERSION=6.7
+ENV WP_CONTENT_DIR=${DOCUMENT_ROOT}/wp-content
+ENV STACK_MEDIA_PATH=/wp-content/uploads
+RUN set -ex \
+    && wp core download --skip-content --path=web/wp --version=${WORDPRESS_VERSION} \
+    && cp /usr/local/docker/webroot/* /app/web/
+ONBUILD COPY --chown=www-data:www-data config /app/config
+ONBUILD COPY --chown=www-data:www-data wp-content /app/web/wp-content

--- a/wordpress/Dockerfile-6.7-php-8.1
+++ b/wordpress/Dockerfile-6.7-php-8.1
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE=docker.io/bitpoke/wordpress-runtime:bedrock-php-8.1
+FROM ${BASE_IMAGE} as bedrock
+ENV WORDPRESS_VERSION=6.7
+ENV WP_CONTENT_DIR=${DOCUMENT_ROOT}/wp-content
+ENV STACK_MEDIA_PATH=/wp-content/uploads
+RUN set -ex \
+    && wp core download --skip-content --path=web/wp --version=${WORDPRESS_VERSION} \
+    && cp /usr/local/docker/webroot/* /app/web/
+ONBUILD COPY --chown=www-data:www-data config /app/config
+ONBUILD COPY --chown=www-data:www-data wp-content /app/web/wp-content

--- a/wordpress/Dockerfile-6.7-php-8.3
+++ b/wordpress/Dockerfile-6.7-php-8.3
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE=docker.io/bitpoke/wordpress-runtime:bedrock-php-8.3
+FROM ${BASE_IMAGE} as bedrock
+ENV WORDPRESS_VERSION=6.7
+ENV WP_CONTENT_DIR=${DOCUMENT_ROOT}/wp-content
+ENV STACK_MEDIA_PATH=/wp-content/uploads
+RUN set -ex \
+    && wp core download --skip-content --path=web/wp --version=${WORDPRESS_VERSION} \
+    && cp /usr/local/docker/webroot/* /app/web/
+ONBUILD COPY --chown=www-data:www-data config /app/config
+ONBUILD COPY --chown=www-data:www-data wp-content /app/web/wp-content


### PR DESCRIPTION
Wordpress 6.7 has been released on November 12th, 2024 so I'm adding docker image for 6.7 on PHP 7.4, 8.1, 8.2, 8.3